### PR TITLE
depend on more recent version of keepassxc-browser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-keepassxc-browser
+git+https://github.com/hrehfeld/python-keepassxc-browser.git@master
 pysodium
 psutil
 keepasshttplib


### PR DESCRIPTION
This commit makes ``ansible-keepass`` require the current upstream git master instead of the outdated version from pypi.

Fixes the following error for me:
```
[ERROR]: The password for root could not be obtained using KeepassXC Browser. Error obtaining host name myhost:
Error in the Ansible Keepass plugin. ProtocolError on connection: Cannot decrypt message
```