### PR TITLE
add slashes when querying for logins

### DIFF
--- a/ansible_keepass.py
+++ b/ansible_keepass.py
@@ -140,7 +140,10 @@ class KeepassXC(KeepassBase):
 
     def get_password(self, host_name):
         try:
-            logins = self.connection.get_logins(self.identity, url='ssh:{}'.format(host_name))
+            logins = self.connection.get_logins(
+                self.identity,
+                url='ssh://{}'.format(host_name)
+            )
         except ProtocolError:
             return
         except Exception as e:


### PR DESCRIPTION
Without, KeePassXC apparently returns all logins which URLs start with "ssh".

Since we pick simply pick the first login returned, it is quite likely that we use the wrong one and the sudo password will not work.

Unfortunately, I could not find some docs for KeePassXC's ``get-logins`` – maybe the colon has a special meaning when not followed by slashes…?!