### PR TITLE
ensure that KeePassXC returned exactly one login

### DIFF
--- a/ansible_keepass.py
+++ b/ansible_keepass.py
@@ -145,6 +145,11 @@ class KeepassXC(KeepassBase):
             return
         except Exception as e:
             raise KeepassXCError('Error obtaining host name {}: {}'.format(host_name, e))
+        if len(logins) > 1:
+            raise KeepassXCError(
+                'Error obtaining host name {}: '.format(host_name) +
+                'multiple values returned'
+            )
         return next(iter(logins), {}).get('password')
 
 


### PR DESCRIPTION
If multiple are returned, it is very likely we pick the wrong one
since we simply pick the first.

See also #2.