### PR TITLE
update process names for detection of KeepassXC

### DIFF
--- a/ansible_keepass.py
+++ b/ansible_keepass.py
@@ -16,7 +16,8 @@ from keepassxc_browser.protocol import ProtocolError
 
 
 KEEPASSXC_CLIENT_ID = 'python-keepassxc-browser'
-KEEPASSXC_PROCESS_NAMES = ['keepassxc', 'keepassxc.exe']
+KEEPASSXC_PROCESS_NAMES = set(('keepassxc', 'keepassxc.exe',
+                               'keepassxc-proxy'))
 KEYRING_KEY = 'assoc'
 
 


### PR DESCRIPTION
On Debian unstable, KeepassXC runs under the process name ``keepassxc-proxy``.
Additionally I made the list a set, so the lookup is faster while searching the list of processes.